### PR TITLE
Use QgsSettings() instead of QtCore.QSettings() and fix to load PostGIS Layers via PostgreSQL service name

### DIFF
--- a/datadriveninputmask.py
+++ b/datadriveninputmask.py
@@ -50,7 +50,7 @@ class DataDrivenInputMask(object):
             self.app.ddManager = ddManager
         # initialize locale
         localePath = ""
-        locale = QtCore.QSettings().value("locale/userLocale")[0:2]
+        locale = QgsSettings().value("locale/userLocale")[0:2]
 
         libPath = os.path.dirname(__file__)
         libPathFound = False

--- a/ddmanager.py
+++ b/ddmanager.py
@@ -56,7 +56,7 @@ class DdManager(object):
     def __init__(self,  iface):
         self.iface = iface
         self.ddLayers = dict()
-        settings = QtCore.QSettings()
+        settings = QgsSettings()
         settings.beginGroup("Qgis/digitizing")
         a = settings.value("line_color_alpha",200,type=int)
         b = settings.value("line_color_blue",0,type=int)
@@ -77,13 +77,13 @@ class DdManager(object):
         return "<ddmanager.DdManager>"
 
     def saveSearchPath(self,  path = ""):
-        settings = QtCore.QSettings()
+        settings = QgsSettings()
         settings.beginGroup("DataDrivenInputMask")
         settings.setValue(u"lastSearchPath", path)
         settings.endGroup()
 
     def getSearchPath(self):
-        settings = QtCore.QSettings()
+        settings = QgsSettings()
         settings.beginGroup("DataDrivenInputMask")
         path = settings.value("lastSearchPath",  "",  type=str)
         settings.endGroup()

--- a/ddui.py
+++ b/ddui.py
@@ -92,7 +92,7 @@ def ddFormInit(dialog, layerId, featureId):
                 result = dlg.exec_()
 
                 if result == 1:
-                    layer.setModified()
+                    aLayer.setModified()
 
 class DdEventFilter(QtCore.QObject):
     '''Event filter class to be applied to DdLineEdit's input widgets


### PR DESCRIPTION
I would reccommend to use QgsSettings() from qgis.core (https://github.com/qgis/QGIS/commit/e1ede700a897c899be8aabf20abe7f953209cb10) instead of QSettings() from PyQt5.QtCore as this consider the use of global configuration via the qgis_global_settings.ini (https://docs.qgis.org/3.34/en/docs/user_manual/introduction/qgis_configuration.html#deploying-qgis-within-an-organization).

Furthermore the method `ddmanager.loadPostGISLayer` was not able to load PostGIS layers via a PostgreSQL service name. The second commit will fix this.